### PR TITLE
Change citebordercolor to tugreen

### DIFF
--- a/thesis.tex
+++ b/thesis.tex
@@ -119,7 +119,7 @@
 
 
 % Last packages, do not change order or insert new packages after these ones
-\usepackage[pdfusetitle, unicode, linkbordercolor=tugreen]{hyperref}
+\usepackage[pdfusetitle, unicode, linkbordercolor=tugreen, citebordercolor=tugreen]{hyperref}
 \usepackage{bookmark}
 \usepackage[shortcuts]{extdash}
 


### PR DESCRIPTION
It has always been bothering me that the color for the links is tugreen, while the color of citations has a slightly different color. This PR fixes the issue, making the borders for both links and citations tugreen.

If this is intentional that the colors are different, I think it would be better to have two colors that are more distinguishable.